### PR TITLE
feat(phase-0): compile environment probe into a script (fixes #2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Phase 0 env probe (self-check)
+        run: python scripts/env_probe.py --self-check
+
       - name: Run research validator on example
         run: python scripts/research_validator.py examples/typescript-cli/RESEARCH.md
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -62,19 +62,14 @@ Read `references/mcp-strategy.md` for MCP usage and fallback logic.
 
 ## Phase 0: Environment Probe
 
-Silently detect: OS (Windows/macOS/Linux), Python version (`python --version` or `python3 --version`), package manager (`uv`, `pip`, `npm`, `pnpm`, `yarn`).
+Run `python scripts/env_probe.py` and parse the JSON. Fields: `os`, `wsl`, `python_version`, `package_managers.{python,node}`, `windows_scripts_path`. Store the result for use in Phases 3, 5, and 6. If the script fails (e.g. Python missing), ask once: "What OS and Python version are you on?"
 
 **Convention scan**: silently check nearby projects for HTTP client, test framework, DB, formatter. Present once in Phase 5: "Your projects use [X]. Match? [Y/n]"
 
-Store results for use in Phases 3, 5, and 6.
-
-**Windows PATH check**: On Windows, detect if the Python Scripts folder is on PATH.
-Run `python -c "import sysconfig; print(sysconfig.get_path('scripts'))"` to get the exact Scripts path.
-Detect shell: if `$PSVersionTable` is accessible = PowerShell; otherwise = CMD.
+**Windows PATH check**: when `os == "windows"` and `wsl == false`, use `windows_scripts_path` from the probe. Detect shell: if `$PSVersionTable` is accessible = PowerShell; otherwise = CMD.
 After any `pip install -e .`, run the installed command immediately. If "not recognized": session fix `$env:PATH += ";[Scripts path]"` (PS) or `set PATH=%PATH%;[Scripts path]` (CMD); permanent fix `[Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";[Scripts path]", "User")`.
 
-**WSL note**: If on Windows but inside WSL, treat as Linux - skip Windows PATH fixes entirely.
-If detection fails, ask once: "What OS and Python version are you on?"
+**WSL note**: when `wsl == true`, treat as Linux - skip Windows PATH fixes entirely.
 
 ---
 

--- a/scripts/env_probe.py
+++ b/scripts/env_probe.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+env_probe.py - Genesis Architect
+
+Phase 0 environment probe. Detects OS, Python version, available package
+managers, and (on Windows) the Python Scripts directory. Returns JSON so the
+skill can consume the result deterministically instead of re-running detection
+inline every time.
+
+Usage:
+  python scripts/env_probe.py
+  python scripts/env_probe.py --pretty       # human-readable indent
+  python scripts/env_probe.py --self-check   # assert required keys are present (for CI)
+"""
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+
+# Order matters: the first available manager is the one most projects in this
+# environment are likely to use. uv before pip (uv is a superset for Python),
+# pnpm/yarn before npm (they're explicit choices when present).
+PYTHON_PACKAGE_MANAGERS = ["uv", "pip"]
+NODE_PACKAGE_MANAGERS = ["pnpm", "yarn", "npm"]
+
+
+def detect_os() -> str:
+    system = platform.system()
+    if system == "Darwin":
+        return "macos"
+    if system == "Linux":
+        return "linux"
+    if system == "Windows":
+        return "windows"
+    return system.lower()
+
+
+def detect_wsl() -> bool:
+    """True if running inside WSL on Windows. Reliable across WSL1 and WSL2."""
+    if detect_os() != "linux":
+        return False
+    try:
+        with open("/proc/version", "r", encoding="utf-8") as f:
+            return "microsoft" in f.read().lower()
+    except OSError:
+        return False
+
+
+def detect_python_version() -> str:
+    return f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+
+
+def detect_package_managers() -> dict:
+    """Return the first available manager per ecosystem (or null if none found)."""
+    return {
+        "python": next((m for m in PYTHON_PACKAGE_MANAGERS if shutil.which(m)), None),
+        "node": next((m for m in NODE_PACKAGE_MANAGERS if shutil.which(m)), None),
+    }
+
+
+def detect_windows_scripts_path() -> str | None:
+    """
+    Returns the Python Scripts directory on Windows (where pip-installed CLIs
+    land). SKILL.md Phase 0 uses this to fix PATH after `pip install -e .`.
+    Returns null on non-Windows systems.
+    """
+    if detect_os() != "windows":
+        return None
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", "import sysconfig; print(sysconfig.get_path('scripts'))"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+        return result.stdout.strip() or None
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
+def probe() -> dict:
+    return {
+        "os": detect_os(),
+        "wsl": detect_wsl(),
+        "python_version": detect_python_version(),
+        "package_managers": detect_package_managers(),
+        "windows_scripts_path": detect_windows_scripts_path(),
+    }
+
+
+REQUIRED_KEYS = ["os", "wsl", "python_version", "package_managers", "windows_scripts_path"]
+
+
+def self_check(report: dict) -> list[str]:
+    """Return a list of validation errors. Empty list = pass."""
+    errors = []
+    for key in REQUIRED_KEYS:
+        if key not in report:
+            errors.append(f"missing key: {key}")
+    if "os" in report and report["os"] not in {"macos", "linux", "windows"}:
+        errors.append(f"unexpected os value: {report['os']!r}")
+    if "package_managers" in report:
+        pm = report["package_managers"]
+        if not isinstance(pm, dict) or set(pm.keys()) != {"python", "node"}:
+            errors.append(f"package_managers must have keys python+node, got {pm!r}")
+    if report.get("os") == "windows" and report.get("windows_scripts_path") is None:
+        errors.append("windows_scripts_path must be set when os=windows")
+    if report.get("os") != "windows" and report.get("windows_scripts_path") is not None:
+        errors.append("windows_scripts_path must be null when os!=windows")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Genesis Architect - Phase 0 environment probe")
+    parser.add_argument("--pretty", action="store_true", help="indent the JSON output")
+    parser.add_argument(
+        "--self-check",
+        action="store_true",
+        help="validate the report shape and exit non-zero on failure (used by CI)",
+    )
+    args = parser.parse_args()
+
+    report = probe()
+
+    if args.self_check:
+        errors = self_check(report)
+        if errors:
+            print("env_probe self-check FAILED:", file=sys.stderr)
+            for e in errors:
+                print(f"  - {e}", file=sys.stderr)
+            return 1
+        print("env_probe self-check OK", file=sys.stderr)
+
+    print(json.dumps(report, indent=2 if args.pretty else None))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Fixes #2.**

> The `Fixes #N` keyword in the PR description (or any commit message) makes GitHub auto-close issue #N when this PR merges into the default branch. Synonyms also work: `Closes #N`, `Resolves #N`. It's the standard way to keep issues and the PRs that resolve them linked. Putting it in the PR body (not just a commit) means the link shows up in the issue's sidebar immediately, so reviewers can jump back and forth.

## What changed

- **New: `scripts/env_probe.py`** — single-file, stdlib-only. Detects OS, WSL, Python version, available package manager (per ecosystem), and the Windows Scripts path. Returns JSON.
- **New flag: `--self-check`** — validates the report shape (required keys, cross-field invariants like "`windows_scripts_path` is set iff `os == windows`") and exits non-zero on failure. CI uses this.
- **`SKILL.md` Phase 0** — replaced the inline detection prose with a single call to the script. The Windows/WSL branches now reference report fields directly (`os == "windows" && wsl == false`, `wsl == true`). Net: -5 lines.
- **`.github/workflows/ci.yml`** — added a `Phase 0 env probe (self-check)` step in `quality-gates`. Misshapen output fails the build.

## Smoke test (run locally)

```
$ python scripts/env_probe.py --pretty
{
  "os": "macos",
  "wsl": false,
  "python_version": "3.14.4",
  "package_managers": {
    "python": "uv",
    "node": "pnpm"
  },
  "windows_scripts_path": null
}

$ python scripts/env_probe.py --self-check
env_probe self-check OK
```

## Why this shape

This is the pattern issues #5 (mitigation coverage check) and #6 (Phase 7 subcommands) should follow:

1. Move the procedure into a script.
2. Add `--self-check` (or equivalent) so CI can verify the contract holds.
3. Reduce the SKILL.md prose to "call the script and parse the JSON."

The result: one inspectable, testable surface per phase instead of prose Claude has to re-interpret every session.

## Out of scope

- Convention scan ("nearby projects use X") — kept as prose; it's environment-dependent in a way the probe isn't.
- Replacing OS-specific PATH advice — the strings are fine as English; what matters is that the probe gives a deterministic boolean to gate them on.

Generated with Claude Code (https://claude.ai/code)
