### PR TITLE
docs: correct test count (2295 to 2337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ that was behind the paywall now ships in this package under AGPL-3.0.
 
 ### Verification
 
-2295 tests passing, 5 skipped, on a clean container install.
+2337 tests passing, 5 skipped, on a clean container install.
 
 ## [5.1.1] - 2026-05-30
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ modules are too fragile to touch.
 [![PyPI](https://img.shields.io/pypi/v/genesis-architect?style=flat-square)](https://pypi.org/project/genesis-architect/)
 [![Python](https://img.shields.io/pypi/pyversions/genesis-architect?style=flat-square)](https://pypi.org/project/genesis-architect/)
 [![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-2295-brightgreen?style=flat-square)](tests/)
+[![Tests](https://img.shields.io/badge/tests-2337-brightgreen?style=flat-square)](tests/)
 
 </div>
 


### PR DESCRIPTION
The README badge and CHANGELOG were written before the genesis_sync coverage and URL hardening tests landed, so they understated actual coverage by 42 tests.

Verified in a clean container: 2337 passed, 5 skipped.