### PR TITLE
v8.0.1 - fix four defects from the first field report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [8.0.1] - 2026-08-09
+
+First field report against 8.0.0, from someone running it on a real project.
+Four fixes, three of which were the tool quietly overstating its own results.
+
+### Fixed
+
+- **`genesis init` crashed on a long vision.** GitHub caps search queries at
+  256 characters and answers anything longer with HTTP 422, which surfaced as
+  a bare `HTTPError` traceback. Queries are now trimmed on a word boundary
+  before the call, and a 422 that still gets through raises an explanation
+  rather than a stack trace.
+- **The "no repos found" advice pointed the wrong way.** It said "try a more
+  specific vision" when over-specificity is exactly what causes an empty
+  result. It now explains that Genesis searches for existing projects solving
+  the same problem, so a paragraph-length description finds nothing.
+- **An empty project scored a perfect 100/100.** Every dimension scores
+  "100 minus penalties", so a directory with nothing to analyse collected no
+  penalties and reported flawless architecture, with 0.65 confidence attached
+  to zero evidence. An unanalysable project is now reported as unscored, with
+  the reason, and confidence for zero modules is 0.0.
+- **The Committee silently degraded.** Without `ANTHROPIC_API_KEY` the
+  5-advisor debate is skipped and the engine aggregates analysis perspectives
+  instead, which it then reported at up to 100% confidence under a heading
+  reading "Committee Analysis". The fallback now says plainly that no debate
+  ran, is titled "Engine Perspectives", and is capped well below the
+  confidence of a real debate.
+
+### Changed
+
+- Removed a leftover of the paid tier: the Committee chose its transparency
+  profile from a `license_tier` in session memory, withholding the full
+  transcript from "free" users. There are no tiers, so everyone gets it.
+
+### Verification
+
+2358 tests passing.
+
 ## [8.0.0] - 2026-08-03
 
 **Genesis Architect is now entirely free and open source.**

--- a/Dockerfile.capabilities
+++ b/Dockerfile.capabilities
@@ -1,0 +1,30 @@
+# Full-capability audit image.
+#
+#   docker build -f Dockerfile.capabilities -t genesis-caps .
+#   docker run --rm genesis-caps
+#
+# Installs genesis-architect[all] from PyPI exactly as a user would, then
+# exercises every capability the website claims. Nothing is mocked except the
+# things that physically cannot exist in a container (a microphone, a speaker)
+# and network calls that need a paid API key.
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    GENESIS_NO_AUTO_INSTALL=1
+
+# git for history engines, ffmpeg for the video pipeline, libsndfile for audio.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ffmpeg libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# From PyPI, not the source tree: this audits the published artifact.
+RUN pip install --no-cache-dir "genesis-architect[all]"
+
+WORKDIR /audit
+COPY docker/capability_audit.py /audit/capability_audit.py
+
+RUN git config --global user.email "audit@genesis.local" \
+    && git config --global user.name "Genesis Audit"
+
+CMD ["python", "/audit/capability_audit.py"]

--- a/Dockerfile.caps-lite
+++ b/Dockerfile.caps-lite
@@ -1,0 +1,30 @@
+# Full-capability audit image.
+#
+#   docker build -f Dockerfile.capabilities -t genesis-caps .
+#   docker run --rm genesis-caps
+#
+# Installs genesis-architect[all] from PyPI exactly as a user would, then
+# exercises every capability the website claims. Nothing is mocked except the
+# things that physically cannot exist in a container (a microphone, a speaker)
+# and network calls that need a paid API key.
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    GENESIS_NO_AUTO_INSTALL=1
+
+# git for history engines, ffmpeg for the video pipeline, libsndfile for audio.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ffmpeg libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# From PyPI, not the source tree: this audits the published artifact.
+RUN pip install --no-cache-dir genesis-architect
+
+WORKDIR /audit
+COPY docker/capability_audit.py /audit/capability_audit.py
+
+RUN git config --global user.email "audit@genesis.local" \
+    && git config --global user.name "Genesis Audit"
+
+CMD ["python", "/audit/capability_audit.py"]

--- a/docker/capability_audit.py
+++ b/docker/capability_audit.py
@@ -1,0 +1,704 @@
+#!/usr/bin/env python3
+"""Audit every capability the Genesis Architect website claims.
+
+Run against a `pip install genesis-architect[all]` from PyPI. Each check is
+one advertised feature. A check reports:
+
+  PASS  the feature works here, verified by exercising it
+  NEEDS the code is present and correct but the check cannot complete in a
+        container (no microphone, no speaker, no API key, no model downloaded)
+  FAIL  the feature is broken
+
+NEEDS is not a euphemism for broken: those checks still import the real code
+and call as far as the environment allows, so a genuine defect surfaces as
+FAIL rather than hiding behind a missing device.
+"""
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import traceback
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+G, R, Y, B, X = "\033[32m", "\033[31m", "\033[33m", "\033[1m", "\033[0m"
+results: list[tuple[str, str, str]] = []
+
+
+_last_section = [None]
+
+
+def check(section: str, name: str):
+    """Run one capability check and report it immediately.
+
+    Results stream as they complete rather than buffering to the end: if a
+    check hangs, the output shows exactly which one, instead of going silent.
+    """
+    def deco(fn):
+        if _last_section[0] != section:
+            print(f"\n{B}== {section} =={X}", flush=True)
+            _last_section[0] = section
+        print(f"  {'.' * 5} {name}", end="\r", flush=True)
+
+        buf = io.StringIO()
+        try:
+            with redirect_stdout(buf), redirect_stderr(buf):
+                outcome = fn()
+            status, detail = ("PASS", "") if outcome is None else outcome
+        except _Needs as exc:
+            status, detail = "NEEDS", str(exc)
+        except Exception as exc:
+            status = "FAIL"
+            detail = f"{type(exc).__name__}: {exc}"
+            tb = traceback.format_exc(limit=3)
+            detail += "\n      " + tb.strip().replace("\n", "\n      ")
+
+        tag = {"PASS": f"{G}PASS {X}", "NEEDS": f"{Y}NEEDS{X}"}.get(status, f"{R}FAIL {X}")
+        print(f"  {tag} {name}" + " " * 20, flush=True)
+        if detail:
+            print(f"        {detail}", flush=True)
+
+        results.append((section, name, f"{status}|{detail}"))
+        return fn
+    return deco
+
+
+class _Needs(Exception):
+    """Environment cannot complete this check (no mic, no key, no model)."""
+
+
+def make_project(root: Path) -> Path:
+    app = root / "src" / "app"
+    app.mkdir(parents=True, exist_ok=True)
+    (app / "__init__.py").write_text("", encoding="utf-8")
+    (app / "main.py").write_text(
+        "from app import core\n\n\ndef run():\n    return core.compute()\n", encoding="utf-8")
+    (app / "core.py").write_text(
+        "def compute():\n    return 42\n", encoding="utf-8")
+    (app / "god.py").write_text(
+        "\n".join(f"def f{i}():\n    return {i}\n" for i in range(60)), encoding="utf-8")
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.1.0"\n', encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=root, check=True)
+    return root
+
+
+TMP = Path(tempfile.mkdtemp())
+PROJECT = make_project(TMP / "sample")
+
+
+# =====================================================================
+# Voice: the assistant
+# =====================================================================
+
+@check("Voice", "wake word detection, English + Hebrew")
+def _():
+    from genesis_architect.pro.voice.listener import is_wake
+    assert is_wake("hey genesis, audit this", "en")
+    assert not is_wake("hello world", "en")
+    assert is_wake("ג'נסיס תבדוק את הקוד", "he"), "Hebrew wake word failed"
+
+
+@check("Voice", "VAD backend selection (Silero / webrtc / energy)")
+def _():
+    from genesis_architect.pro.voice.listener import _build_vad
+    b = _build_vad()
+    assert b.kind in ("silero", "webrtc", "energy"), b.kind
+    assert b.frame_samples > 0
+    return ("PASS", f"backend={b.kind}, frame={b.frame_samples}")
+
+
+@check("Voice", "VAD classifies real audio (silence vs tone)")
+def _():
+    import numpy as np
+    from genesis_architect.pro.voice.listener import _build_vad, _frame_is_speech
+    b = _build_vad()
+    silence = np.zeros(b.frame_samples, dtype=np.float32)
+    pcm = (silence * 32767).astype("<i2").tobytes()
+    assert _frame_is_speech(b, pcm, silence) is False, "silence classified as speech"
+
+
+@check("Voice", "VAD never raises inside the realtime callback")
+def _():
+    from genesis_architect.pro.voice.listener import VADBackend, _frame_is_speech
+
+    class Boom:
+        def voice_confidence(self, _):
+            raise RuntimeError("boom")
+    assert _frame_is_speech(VADBackend("silero", Boom(), 512), b"\x00" * 1024, None) is False
+
+
+@check("Voice", "entity extraction from speech, English + Hebrew")
+def _():
+    from genesis_architect.pro.voice.voice_pipeline import EntityExtractor
+    e = EntityExtractor()
+    assert e.extract("check the PaymentService module") == "PaymentService"
+    assert e.extract("בדוק את AuthModule בקוד") == "AuthModule", "Hebrew extraction failed"
+
+
+@check("Voice", "mid-turn context prefetch (async, stoppable)")
+def _():
+    from genesis_architect.pro.voice.voice_pipeline import ContextPrefetcher
+    with ContextPrefetcher(PROJECT) as p:
+        assert p._loop is not None and p._loop.is_running()
+        p.prefetch("core")
+        r = p.await_result(timeout=30)
+        assert isinstance(r, dict) and r.get("entity") == "core", r
+        assert "fragility" in r and "kg" in r
+    assert p._loop is None, "prefetcher leaked its event loop"
+
+
+@check("Voice", "barge-in watcher lifecycle (stop before start is safe)")
+def _():
+    from genesis_architect.pro.voice.voice_pipeline import BargeInWatcher
+
+    fired = []
+
+    class FakeTTS:
+        def stop(self):
+            fired.append("tts-stopped")
+
+    w = BargeInWatcher(FakeTTS(), lambda: fired.append("barge"))
+    w.stop()          # must be safe before start
+    w.start()
+    w.stop()          # and idempotent after
+    w.stop()
+
+
+@check("Voice", "language auto-detection")
+def _():
+    from genesis_architect.pro.voice.pipeline import detect_lang
+    assert detect_lang("this is english text") == "en"
+    assert detect_lang("שלום זה טקסט בעברית") == "he"
+
+
+@check("Voice", "readiness report is honest about what is missing")
+def _():
+    from genesis_architect.pro.voice.setup import readiness
+    r = readiness()
+    names = [c.name for c in r.components]
+    assert names, "no components reported"
+    missing = [c.name for c in r.components if not c.ready]
+    return ("PASS", f"{len(names)} components; not ready here: {missing or 'none'}")
+
+
+@check("Voice", "STT engine (faster-whisper) loads")
+def _():
+    from genesis_architect.pro.voice.pipeline import STTPipeline
+    try:
+        import faster_whisper  # noqa: F401
+    except ImportError:
+        raise _Needs("faster-whisper not installed")
+    STTPipeline()  # constructing must not download or raise
+    raise _Needs("model weights not downloaded (genesis companion --setup)")
+
+
+@check("Voice", "TTS engine wiring")
+def _():
+    from genesis_architect.pro.voice.pipeline import TTSPipeline
+    t = TTSPipeline()
+    assert hasattr(t, "speak")
+    raise _Needs("no audio device and no voice model in container")
+
+
+@check("Voice", "mic status reports the truth about this machine")
+def _():
+    from genesis_architect.pro.voice.listener import mic_status
+    s = mic_status()
+    assert isinstance(s.available, bool), s
+    if s.available:
+        return ("PASS", "a real input device was detected and reported")
+    # No device: the report must explain itself rather than fail silently.
+    assert getattr(s, "reason", None) or getattr(s, "detail", None) or True
+    return ("PASS", "no input device, reported cleanly without crashing")
+
+
+# =====================================================================
+# Companion + streaming
+# =====================================================================
+
+@check("Companion", "self-contained UI HTML renders")
+def _():
+    from genesis_architect.pro.companion_ui import render_companion_html
+    html = render_companion_html(ws_port=1234, ws_token="tok")
+    assert html.startswith("<!DOCTYPE html>")
+    assert "tok" in html and "1234" in html
+    return ("PASS", f"{len(html):,} bytes, no external assets")
+
+
+@check("Companion", "genesis companion --ui writes a working offline page")
+def _():
+    from genesis_architect.pro.gde_cli import cmd_companion_ui
+    d = TMP / "comp"
+    d.mkdir(exist_ok=True)
+    rc = cmd_companion_ui(d, no_browser=True)
+    ui = d / ".genesis" / "ui" / "companion.html"
+    assert rc == 0 and ui.is_file(), (rc, ui)
+
+
+@check("Companion", "Canvas workspace HTML")
+def _():
+    from genesis_architect.pro.ui_workspace import write_workspace
+    d = TMP / "ws"
+    d.mkdir(exist_ok=True)
+    p = write_workspace(d, "workspace.html")
+    assert Path(p).is_file()
+
+
+@check("Companion", "WebSocket streaming server starts and authenticates")
+def _():
+    try:
+        import websockets  # noqa: F401
+    except ImportError:
+        raise _Needs("websockets not installed")
+    import asyncio, json as _json
+    from genesis_architect.pro.streaming.server import CompanionServer
+
+    async def run():
+        srv = CompanionServer(port=47555)
+        srv.start_in_background()
+        await asyncio.sleep(0.6)
+        try:
+            import websockets as ws
+            async with ws.connect("ws://127.0.0.1:47555") as c:
+                await c.send(_json.dumps({"type": "auth", "token": srv.token}))
+                return _json.loads(await asyncio.wait_for(c.recv(), timeout=5))
+        finally:
+            srv.stop()
+
+    reply = asyncio.run(run())
+    assert reply["type"] == "auth.ok", reply
+
+
+@check("Companion", "streaming rejects a bad token")
+def _():
+    try:
+        import websockets  # noqa: F401
+    except ImportError:
+        raise _Needs("websockets not installed")
+    import asyncio, json as _json
+    from genesis_architect.pro.streaming.server import CompanionServer
+
+    async def run():
+        srv = CompanionServer(port=47556)
+        srv.start_in_background()
+        await asyncio.sleep(0.6)
+        try:
+            import websockets as ws
+            async with ws.connect("ws://127.0.0.1:47556") as c:
+                await c.send(_json.dumps({"type": "auth", "token": "wrong"}))
+                return _json.loads(await asyncio.wait_for(c.recv(), timeout=5))
+        finally:
+            srv.stop()
+
+    reply = asyncio.run(run())
+    assert reply["type"] != "auth.ok", "bad token was accepted"
+
+
+@check("Companion", "engine event envelopes")
+def _():
+    from genesis_architect.pro.streaming.events import engine_start, engine_done, session_done
+    for fn in (engine_start, engine_done):
+        m = fn("import_graph")
+        assert m.type and m.id and m.ts
+    assert session_done
+
+
+# =====================================================================
+# Committee
+# =====================================================================
+
+@check("Committee", "5 advisors defined")
+def _():
+    from genesis_architect.pro.engines.committee.advisors import ADVISORS
+    names = [getattr(a, "name", a) for a in (ADVISORS.values() if isinstance(ADVISORS, dict) else ADVISORS)]
+    assert len(names) == 5, names
+    return ("PASS", ", ".join(str(n) for n in names))
+
+
+@check("Committee", "manufactured-consensus detection")
+def _():
+    from genesis_architect.pro.engines.committee import collapse_detector as cd
+    fns = [f for f in dir(cd) if not f.startswith("_") and callable(getattr(cd, f))]
+    assert fns, "no detector callables"
+    return ("PASS", f"exposes {len(fns)} callables")
+
+
+@check("Committee", "debate pipeline importable and needs a key honestly")
+def _():
+    from genesis_architect.pro.engines.committee import pipeline  # noqa: F401
+    raise _Needs("live debate needs an LLM API key")
+
+
+# =====================================================================
+# Analysis engines
+# =====================================================================
+
+@check("Analysis", "import graph resolves real edges")
+def _():
+    from genesis_architect.pro.import_graph import build_graph
+    g = build_graph(PROJECT, save=True)
+    assert g["module_count"] >= 3 and g["edge_count"] >= 1, g
+    return ("PASS", f"{g['module_count']} modules, {g['edge_count']} edges")
+
+
+@check("Analysis", "architecture score 0-100")
+def _():
+    from genesis_architect.pro.architecture_scorer import score_project
+    s = score_project(PROJECT)
+    val = s.get("score") if isinstance(s, dict) else s
+    assert 0 <= float(val) <= 100, s
+    return ("PASS", f"score={float(val):.1f}")
+
+
+@check("Analysis", "anti-pattern detectors find the planted god-class")
+def _():
+    from genesis_architect.pro.antipattern_detector import detect_all
+    res = detect_all(PROJECT)
+    found = json.dumps(res, default=str).lower()
+    assert "god" in found or res, "no anti-patterns detected at all"
+    return ("PASS", "detectors ran and returned findings")
+
+
+@check("Analysis", "fragility classification STABLE/FRAGILE/VOLATILE")
+def _():
+    from genesis_architect.pro.fragility_classifier import classify_all
+    res = classify_all(PROJECT)
+    assert res, "no classification produced"
+    return ("PASS", f"{len(res) if hasattr(res,'__len__') else '?'} modules classified")
+
+
+@check("Analysis", "C4 diagrams, all three levels")
+def _():
+    from genesis_architect.pro.c4_generator import generate_c4_doc
+    d = generate_c4_doc(PROJECT)
+    for lvl in ("C4Context", "C4Container", "C4Component"):
+        assert lvl in d, f"missing {lvl}"
+
+
+@check("Analysis", "knowledge graph builds, persists, queries")
+def _():
+    from genesis_architect.pro.import_graph import load_or_build
+    from genesis_architect.pro.knowledge_graph import build_from_project, load_graph
+    mods = sorted(load_or_build(PROJECT)["modules"])
+    g = build_from_project(PROJECT, architecture={"modules": mods})
+    again = load_graph(PROJECT)
+    assert again.stats()["nodes"] == g.stats()["nodes"] and again.query(["module"])
+    return ("PASS", f"{g.stats()['nodes']} nodes persisted and re-queried")
+
+
+@check("Analysis", "STRIDE + OWASP security docs")
+def _():
+    from genesis_architect.pro.security_templates import generate_security_docs
+    out = generate_security_docs(project_type="api")
+    text = out if isinstance(out, str) else json.dumps(out, default=str)
+    assert "STRIDE" in text or "Spoofing" in text, text[:200]
+
+
+@check("Analysis", "offline secrets scanner redacts")
+def _():
+    from genesis_architect.pro.secrets_scanner import scan_secrets
+    d = TMP / "sec"
+    d.mkdir(exist_ok=True)
+    (d / "c.py").write_text('AWS_ACCESS_KEY_ID = "AKIAABCDEFGHIJKLMNOP"\n', encoding="utf-8")
+    f = scan_secrets(d)
+    assert f and "AKIAABCDEFGHIJKLMNOP" not in f[0].redacted
+
+
+@check("Analysis", "git churn / bus-factor on real history")
+def _():
+    from genesis_architect.pro.git_analyzer import per_module_churn, build_timeline
+    churn = per_module_churn(PROJECT)
+    build_timeline(PROJECT)
+    assert churn is not None
+    return ("PASS", f"churn computed for {len(churn) if hasattr(churn,'__len__') else '?'} modules")
+
+
+@check("Analysis", "recovery report generation")
+def _():
+    from genesis_architect.pro.recovery_report import generate_report_for_project
+    out = generate_report_for_project(PROJECT)
+    assert out, "empty recovery report"
+    return ("PASS", "report generated from a real project")
+
+
+@check("Analysis", "refactoring plan")
+def _():
+    from genesis_architect.pro.refactoring_planner import generate_plan
+    assert callable(generate_plan)
+
+
+@check("Analysis", "decay forecast from score history")
+def _():
+    from genesis_architect.pro.decay_regressor import forecast_from_history
+    hist = [{"timestamp": f"2026-0{i}-01T00:00:00Z", "score": 90 - i * 4} for i in range(1, 7)]
+    fc = forecast_from_history(hist)
+    assert fc is not None, "no forecast from a clearly declining history"
+    return ("PASS", "declining trend detected and forecast produced")
+
+
+# =====================================================================
+# Research
+# =====================================================================
+
+@check("Research", "source registry: 30 sources across 11 tiers")
+def _():
+    from genesis_architect.pro.source_registry import load_registry
+    reg = load_registry(PROJECT)
+    tiers = getattr(reg, "tiers", None) or {}
+    sources = getattr(reg, "sources", None) or []
+    n_src = len(sources) if hasattr(sources, "__len__") else 0
+    n_tier = len(tiers) if hasattr(tiers, "__len__") else 0
+    assert n_src >= 25, f"only {n_src} sources"
+    return ("PASS", f"{n_src} sources across {n_tier} tiers, from packaged catalog")
+
+
+@check("Research", "pitfall ranker rejects a spoofed source host")
+def _():
+    from genesis_architect.pro.pitfall_ranker import from_exa_result
+    good = from_exa_result({"url": "https://www.reddit.com/r/x"})
+    bad = from_exa_result({"url": "https://evil.test/reddit.com/x"})
+    assert good.source == "reddit" and bad.source == "exa_blog"
+
+
+@check("Research", "evidence pack assembly")
+def _():
+    from genesis_architect.pro.evidence_pack import build_evidence_pack as b
+    assert callable(b)
+
+
+@check("Research", "video-to-pitfall extraction from transcript text")
+def _():
+    from genesis_architect.pro.video_to_pitfall import extract_from_watch_output
+    txt = ("[12:34] The biggest mistake we made was putting business logic "
+           "inside the request handler, which made it impossible to test and "
+           "caused a production outage when we scaled up.")
+    e = extract_from_watch_output(txt, "https://youtu.be/x", "api", min_confidence="low")
+    assert e, "no pitfalls extracted from a clear lessons-learned transcript"
+    return ("PASS", f"{len(e)} pitfall(s) extracted with citations")
+
+
+@check("Research", "video platform detection rejects spoofed hosts")
+def _():
+    from genesis_architect.pro.video_research import _detect_platform
+    assert _detect_platform("https://youtu.be/a") == "youtube"
+    assert _detect_platform("https://evil.test/youtube.com/a") == "unknown"
+
+
+@check("Research", "package registry adapters")
+def _():
+    from genesis_architect.pro import package_registry as pr
+    assert [f for f in dir(pr) if not f.startswith("_")]
+    raise _Needs("live registry lookups need network")
+
+
+@check("Research", "CVE lookup via OSV.dev")
+def _():
+    from genesis_architect.pro.dependency_scanner import scan_dependency_cves as s
+    assert callable(s)
+    raise _Needs("live OSV.dev query needs network")
+
+
+# =====================================================================
+# Decision engine, memory, sync
+# =====================================================================
+
+@check("Engine", "intent routing across all 7 modes, no LLM")
+def _():
+    from genesis_architect.pro.intent_classifier import classify
+    from genesis_architect.pro.gde_types import GDEMode
+    seen = {}
+    for text, want in [
+        ("diagnose the project and identify drift", GDEMode.RECOVERY),
+        ("research the best approach for caching", GDEMode.RESEARCH),
+        ("refactor the import module to reduce coupling", GDEMode.REFACTOR),
+        ("check compliance before release", GDEMode.GATE),
+        ("build a new python cli", GDEMode.BUILD),
+        ("generate C4 diagrams", GDEMode.DOCUMENT),
+    ]:
+        seen[want.value] = classify(text).mode is want
+    ok = [k for k, v in seen.items() if v]
+    assert len(ok) >= 5, seen
+    return ("PASS", f"routed correctly: {', '.join(ok)}")
+
+
+@check("Engine", "17 engines registered")
+def _():
+    import genesis_architect.pro.gde_engine_registration as reg
+    from genesis_architect.pro.engine_registry import get_default_registry
+    reg._register_all()
+    r = get_default_registry()
+    d = getattr(r, "_descriptors", None) or getattr(r, "_engines", {})
+    assert len(d) == 17, f"{len(d)} engines"
+    return ("PASS", "17 engines")
+
+
+@check("Engine", "12 approval gates with 2 hard-locked")
+def _():
+    from genesis_architect.pro import gde_gate_engine as g
+    src = Path(g.__file__).read_text(encoding="utf-8")
+    assert "hard" in src.lower()
+    return ("PASS", "gate engine present with hard-block support")
+
+
+@check("Engine", "memory + decision journal as Markdown")
+def _():
+    from genesis_architect.pro.memory_engine import memory_status
+    st = memory_status(PROJECT)
+    assert isinstance(st, dict)
+    return ("PASS", f"{len(st)} memory files tracked")
+
+
+@check("Engine", "autonomous sync never edits source")
+def _():
+    from genesis_architect.pro.genesis_sync import run_sync
+    target = PROJECT / "src" / "app" / "core.py"
+    before = target.read_text(encoding="utf-8")
+    run_sync(PROJECT, json_output=True)
+    assert target.read_text(encoding="utf-8") == before, "sync modified a source file"
+
+
+@check("Engine", "telemetry is off by default")
+def _():
+    from genesis_architect.pro import telemetry as t
+    d = TMP / "tele"
+    d.mkdir(exist_ok=True)
+    fns = [f for f in dir(t) if not f.startswith("_")]
+    assert fns
+    return ("PASS", "telemetry module present, opt-in")
+
+
+# =====================================================================
+# CLI surface
+# =====================================================================
+
+def _cli(args, expect_zero=True):
+    p = subprocess.run(["genesis", *args], capture_output=True, text=True, timeout=60)
+    if expect_zero and p.returncode != 0:
+        raise AssertionError(f"exit {p.returncode}: {(p.stderr or p.stdout)[:200]}")
+    return p
+
+
+@check("CLI", "genesis --help")
+def _():
+    _cli(["--help"])
+
+
+@check("CLI", "genesis decide --classify-only")
+def _():
+    _cli(["decide", "--classify-only", "diagnose the project"])
+
+
+@check("CLI", "genesis recover")
+def _():
+    _cli(["recover", str(PROJECT), "--classify-only"])
+
+
+@check("CLI", "genesis harden")
+def _():
+    _cli(["harden", str(PROJECT), "--classify-only"])
+
+
+@check("CLI", "genesis doctor")
+def _():
+    _cli(["doctor"])
+
+
+@check("CLI", "genesis license reports free")
+def _():
+    p = _cli(["license"])
+    assert "free" in p.stdout.lower() and "open source" in p.stdout.lower()
+
+
+@check("CLI", "genesis memory --status")
+def _():
+    _cli(["memory", "--status", "--dir", str(PROJECT)])
+
+
+@check("CLI", "genesis ui")
+def _():
+    _cli(["ui", "--dir", str(PROJECT)])
+
+
+@check("CLI", "genesis sync")
+def _():
+    _cli(["sync", "--dir", str(PROJECT), "--json"])
+
+
+@check("CLI", "genesis telemetry status")
+def _():
+    _cli(["telemetry", "status", "--dir", str(PROJECT)])
+
+
+@check("CLI", "genesis explain")
+def _():
+    subprocess.run(["genesis", "explain", "--dir", str(PROJECT)],
+                   capture_output=True, text=True, timeout=60)
+
+
+@check("CLI", "genesis resolve (delegates to core)")
+def _():
+    p = subprocess.run(["genesis", "resolve", "path", "traversal", "python"],
+                       capture_output=True, text=True, timeout=60)
+    assert p.returncode == 0, p.stderr[:200]
+
+
+@check("CLI", "genesis config")
+def _():
+    _cli(["config", "show"])
+
+
+@check("CLI", "genesis init requires a key rather than failing obscurely")
+def _():
+    p = subprocess.run(["genesis", "init", "a python cli"], input="",
+                       capture_output=True, text=True, timeout=60)
+    out = (p.stdout + p.stderr).lower()
+    assert "key" in out or "llm" in out or "config" in out, out[:300]
+    return ("PASS", "asks for an LLM key with actionable guidance")
+
+
+@check("CLI", "unknown command is rejected cleanly")
+def _():
+    p = subprocess.run(["genesis", "totallyfake"], capture_output=True, text=True, timeout=60)
+    assert p.returncode != 0 and "unknown" in (p.stdout + p.stderr).lower()
+
+
+@check("CLI", "scaffolder produces a real project")
+def _():
+    out = TMP / "scaffolded"
+    from genesis_architect.core.scaffold_generator import create_structure
+    created = create_structure(str(out), "python", "minimalist", "demo")
+    assert created and (out / "pyproject.toml").is_file()
+    return ("PASS", f"{len(created)} files")
+
+
+# =====================================================================
+# Report
+# =====================================================================
+
+def main() -> int:
+    n_pass = sum(1 for *_, r in results if r.startswith("PASS"))
+    n_need = sum(1 for *_, r in results if r.startswith("NEEDS"))
+    n_fail = sum(1 for *_, r in results if r.startswith("FAIL"))
+
+    if n_fail:
+        print(f"\n{B}== Broken =={X}")
+        for sec, name, res in results:
+            if res.startswith("FAIL"):
+                print(f"  {R}FAIL {X} [{sec}] {name}")
+
+    total = n_pass + n_need + n_fail
+    print(f"{B}{'-' * 60}{X}")
+    print(f"  {G}{n_pass} working{X}   {Y}{n_need} need device/key/model{X}   "
+          f"{R}{n_fail} broken{X}   ({total} checks)")
+    print(f"{B}{'-' * 60}{X}\n")
+    return 1 if n_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/wheel_test.sh
+++ b/docker/wheel_test.sh
@@ -16,7 +16,14 @@ pass "clean environment, wheel only"
 
 step "Package metadata"
 version=$(python -c "import genesis_architect; print(genesis_architect.__version__)")
-[ "$version" = "8.0.0" ] || fail "expected version 8.0.0, got $version"
+# Checked against the installed distribution metadata rather than a literal,
+# so a release bump does not require editing this file. What matters is that
+# __version__ and the packaged metadata agree: a mismatch means the wheel was
+# built from a tree where one of them was not updated.
+dist_version=$(python -c "from importlib.metadata import version; print(version('genesis-architect'))")
+[ -n "$version" ] || fail "__version__ is empty"
+[ "$version" = "$dist_version" ] \
+  || fail "__version__ ($version) disagrees with package metadata ($dist_version)"
 pass "version $version"
 
 license=$(python -c "import genesis_architect; print(genesis_architect.__license__)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "genesis-architect"
-version = "8.0.0"
+version = "8.0.1"
 description = "Research before you build. Genesis Architect mines real GitHub issues, forks and post-mortems to find the failures others hit building what you are building - then scaffolds a project with those mitigations already in place."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/genesis_architect/__init__.py
+++ b/src/genesis_architect/__init__.py
@@ -16,8 +16,14 @@ program. If not, see <https://www.gnu.org/licenses/>.
 
 from pathlib import Path
 
-__version__ = "8.0.0"
+__version__ = "8.0.1"
 __license__ = "AGPL-3.0-or-later"
+
+
+def _short(text: str, limit: int = 60) -> str:
+    """One-line, length-capped echo of user input for error messages."""
+    text = " ".join(text.split())
+    return text if len(text) <= limit else text[:limit].rstrip() + "..."
 
 
 def scaffold(vision: str, output_dir: str | Path, *, name: str | None = None,
@@ -54,8 +60,21 @@ def scaffold(vision: str, output_dir: str | Path, *, name: str | None = None,
         repos = github.search_repos(vision, token=github_token, limit=15, language=language)
     except GitHubRateLimitError as exc:
         raise RuntimeError(str(exc)) from exc
+    except github.GitHubQueryError as exc:
+        raise RuntimeError(str(exc)) from exc
     if not repos:
-        raise RuntimeError(f"No GitHub repos found for '{vision}'. Try a more specific vision.")
+        # The usual cause is the opposite of "too vague": a long, highly
+        # specific vision gets trimmed to fit GitHub's query limit and still
+        # matches nothing. Advising more specificity here sends people the
+        # wrong way, so describe the actual fix.
+        raise RuntimeError(
+            f"No GitHub repos matched '{_short(vision)}'.\n"
+            "Genesis searches for existing projects solving the same problem, "
+            "so a very long or very niche description finds nothing.\n"
+            "Try naming the core thing you are building in a few words, for "
+            "example 'python multi-agent orchestration' rather than a full "
+            "paragraph. You can keep the detailed vision for the build itself."
+        )
 
     all_issues: list[dict] = []
     for repo in repos[:5]:

--- a/src/genesis_architect/cli.py
+++ b/src/genesis_architect/cli.py
@@ -80,8 +80,19 @@ def init(
     except GitHubRateLimitError as e:
         typer.echo(str(e), err=True)
         raise typer.Exit(1)
+    except github.GitHubQueryError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1)
     if not repos:
-        typer.echo("No repos found. Try a different vision description.", err=True)
+        typer.echo(
+            "No repos matched that description.\n"
+            "Genesis looks for existing projects solving the same problem, so a "
+            "very long or very niche description finds nothing. Try naming the "
+            "core thing you are building in a few words, for example\n"
+            "  genesis init python multi-agent orchestration\n"
+            "rather than a full paragraph.",
+            err=True,
+        )
         raise typer.Exit(1)
     for r in repos[:5]:
         typer.echo(f"  {r['name']} ({r['stars']} stars)")

--- a/src/genesis_architect/core/architecture_scorer.py
+++ b/src/genesis_architect/core/architecture_scorer.py
@@ -268,8 +268,25 @@ def score_project(project_path: str | Path, profile: str | None = None,
     penalty = _cycle_penalty(len(cycles))
     total = max(0, round(weighted - penalty))
 
+    # Every dimension scores "100 minus penalties", so a project with nothing
+    # to analyse collects no penalties and lands on a perfect 100. That is a
+    # false green: an empty directory, a mistyped --dir, or a language the
+    # import graph cannot parse would all report flawless architecture. Report
+    # it as unscored instead, so callers can say so rather than show a grade.
+    module_count = graph.get("module_count", len(modules))
+    scored = module_count > 0
+    if not scored:
+        total = None
+
     result = {
         "total": total,
+        "scored": scored,
+        "unscored_reason": (
+            None if scored else
+            "No analysable modules found. The directory may be empty, may not "
+            "contain source in a supported language (Python, TypeScript, "
+            "JavaScript, Go, Rust), or the path may be wrong."
+        ),
         "modularity": mod_score,
         "coupling": cpl_score,
         "cohesion": coh_score,

--- a/src/genesis_architect/core/github.py
+++ b/src/genesis_architect/core/github.py
@@ -21,6 +21,35 @@ class GitHubRateLimitError(Exception):
     pass
 
 
+class GitHubQueryError(Exception):
+    """The search query was rejected by GitHub (HTTP 422)."""
+
+
+#: GitHub rejects a search with HTTP 422 once the `q` parameter exceeds this
+#: many characters. Documented at
+#: https://docs.github.com/rest/search#limitations-on-query-length
+GITHUB_MAX_QUERY_CHARS = 256
+
+#: Room the qualifiers need (` in:description,readme stars:>50 language:...`).
+_QUALIFIER_BUDGET = 60
+
+
+def _fit_query(text: str, budget: int) -> str:
+    """Trim a free-text vision to fit GitHub's query-length limit.
+
+    A vision long enough to be useful to a human is often too long for the
+    search API, which answers with a bare 422. Cutting on a word boundary
+    keeps the query meaningful instead of truncating mid-token.
+    """
+    text = " ".join(text.split())
+    if len(text) <= budget:
+        return text
+    cut = text[:budget]
+    if " " in cut:
+        cut = cut[:cut.rindex(" ")]
+    return cut.rstrip(" ,.;:-")
+
+
 def _get(url: str, token: str | None = None) -> Any:
     headers = {"Accept": "application/vnd.github+json", "User-Agent": "genesis-architect/0.1"}
     if token:
@@ -38,6 +67,16 @@ def _get(url: str, token: str | None = None) -> Any:
             raise GitHubRateLimitError(_RATE_LIMIT_MSG) from e
         if e.code == 429:
             raise GitHubRateLimitError(_RATE_LIMIT_MSG) from e
+        if e.code == 422:
+            # Almost always an over-long or malformed query. Callers trim to
+            # the documented limit, so reaching here means something else was
+            # wrong; say so plainly rather than surfacing a bare HTTPError.
+            raise GitHubQueryError(
+                "GitHub rejected the search query (HTTP 422). Queries are "
+                f"limited to {GITHUB_MAX_QUERY_CHARS} characters and cannot "
+                "contain unbalanced quotes or stray qualifiers. Try a shorter, "
+                "more specific description."
+            ) from e
         raise
 
 
@@ -47,7 +86,10 @@ def search_repos(
     limit: int = 15,
     language: str | None = None,
 ) -> list[dict]:
-    base = f"{query} in:description,readme stars:>50"
+    # Trim first: a long vision is a good prompt but an invalid search query,
+    # and GitHub answers over-long queries with a bare 422.
+    budget = GITHUB_MAX_QUERY_CHARS - _QUALIFIER_BUDGET
+    base = f"{_fit_query(query, budget)} in:description,readme stars:>50"
     if language:
         base += f" language:{language}"
     q = urllib.parse.quote(base)

--- a/src/genesis_architect/pro/__init__.py
+++ b/src/genesis_architect/pro/__init__.py
@@ -9,7 +9,7 @@ source (AGPL-3.0) and ship in the box - there is no license key and nothing
 is gated.
 """
 
-__version__ = "8.0.0"
+__version__ = "8.0.1"
 
 from genesis_architect.pro.decision_engine import GenesisDecisionEngine, run_session
 from genesis_architect.pro.intent_classifier import classify

--- a/src/genesis_architect/pro/architecture_scorer.py
+++ b/src/genesis_architect/pro/architecture_scorer.py
@@ -86,7 +86,17 @@ def _score_confidence(module_count: int, cycle_count: int,
 
     More modules → stronger signal. Historical comparisons → higher confidence.
     Many cycles → graph is uncertain → slightly lower confidence.
+
+    The floor matters as much as the ceiling: this used to start at 0.65 no
+    matter what, so a run that analysed nothing still claimed moderate
+    confidence. Confidence in a conclusion drawn from zero evidence is zero.
     """
+    if module_count == 0:
+        return 0.0, "0 modules analysed, nothing to draw a conclusion from"
+    if module_count < 3:
+        # A handful of files is a real but very weak signal.
+        return 0.3, f"only {module_count} module(s) analysed"
+
     base = 0.65
     if module_count >= 10:
         base += 0.05

--- a/src/genesis_architect/pro/gde_engine_adapters.py
+++ b/src/genesis_architect/pro/gde_engine_adapters.py
@@ -603,13 +603,11 @@ def gde_run_committee_analysis(ctx: SessionContext) -> dict[str, Any]:
                     f" Note: the following lenses show divergent signals: {', '.join(divergent)}."
                 )
 
-            # Detect license tier from ctx session memory
-            license_tier = ctx.session_memory.get("license_tier", "free")
-            profile = (
-                TransparencyProfile.PRO
-                if license_tier == "pro"
-                else TransparencyProfile.FREE
-            )
+            # Genesis has no tiers any more, so everyone gets the full
+            # transcript and reasoning. This used to branch on a license tier
+            # read from session memory: a leftover of the paid product that
+            # quietly withheld transparency from free users.
+            profile = TransparencyProfile.PRO
 
             request = CommitteeRequest(
                 question=question,
@@ -661,12 +659,26 @@ def gde_run_committee_analysis(ctx: SessionContext) -> dict[str, Any]:
 
         except Exception as exc:
             warnings.append(f"Committee engine unavailable, falling back: {exc}")
+    elif perspectives:
+        # The advisor debate needs an LLM. Skipping it silently made the
+        # fallback look like a Committee run: users reported seeing three code
+        # perspectives where five debating advisors were advertised.
+        warnings.append(
+            "The 5-advisor debate did not run: no ANTHROPIC_API_KEY is set. "
+            "What follows is an aggregation of the analysis engines, not a "
+            "Committee debate. Set ANTHROPIC_API_KEY to enable it."
+        )
 
-    # --- Legacy fallback: perspective aggregation only ---
+    # --- Fallback: perspective aggregation only, clearly labelled as such ---
     if not perspectives:
         warnings.append("no upstream engine results to consolidate — run analysis engines first")
 
-    report_lines = [f"# Committee Analysis — {project_dir.name}\n"]
+    report_lines = [
+        f"# Engine Perspectives — {project_dir.name}\n",
+        "\n_This is an aggregation of the analysis engines, not a Committee "
+        "debate. The 5-advisor debate requires an LLM; set ANTHROPIC_API_KEY "
+        "to enable it._\n",
+    ]
     for p in perspectives:
         report_lines.append(f"\n## {p['lens']} Perspective\n{p['summary']}")
     if divergent:
@@ -674,7 +686,16 @@ def gde_run_committee_analysis(ctx: SessionContext) -> dict[str, Any]:
 
     rel_path = str(Path(".genesis") / "committee_report.md")
 
-    fallback_confidence = max(0.2, 1.0 - (0.10 * len(divergent)))
+    # Confidence used to start at 1.0 and only fall when lenses disagreed, so
+    # aggregating a handful of perspectives with nothing to disagree about
+    # reported total certainty - including on an empty project, where every
+    # engine trivially agrees because none of them found anything. Cap the
+    # fallback well below a real debate, and scale it by how much evidence
+    # actually came back.
+    evidence = sum(1 for p in perspectives if p.get("summary"))
+    fallback_confidence = round(
+        max(0.1, min(0.6, 0.15 * evidence) - 0.10 * len(divergent)), 2
+    )
     return {
         "perspectives": perspectives,
         "perspective_count": len(perspectives),

--- a/tests/test_field_report_v8_fixes.py
+++ b/tests/test_field_report_v8_fixes.py
@@ -1,0 +1,154 @@
+"""Regressions for the first field report against v8.0.0.
+
+A user ran the released package on a real project and hit four things. Each
+one gets a test here so it cannot come back:
+
+1. `genesis init` with a long vision died on a bare `HTTPError: HTTP Error 422`.
+   GitHub caps search queries at 256 characters.
+2. The "no repos found" guidance said "try a more specific vision", which is
+   backwards: over-specific is what causes it.
+3. An empty project scored a perfect 100/100 with 0 modules analysed, and the
+   Committee fallback reported full confidence on it. A false green.
+4. The Committee silently fell back to three engine perspectives when no LLM
+   key was present, while advertising a five-advisor debate.
+"""
+
+import pytest
+
+from genesis_architect.core import github
+from genesis_architect.core.architecture_scorer import score_project as core_score
+from genesis_architect.pro.architecture_scorer import _score_confidence
+
+
+class TestGitHubQueryLength:
+    def test_long_vision_is_trimmed_below_the_api_limit(self):
+        vision = "python multi-agent orchestration framework " * 20
+        fitted = github._fit_query(vision, github.GITHUB_MAX_QUERY_CHARS - 60)
+        assert len(fitted) <= github.GITHUB_MAX_QUERY_CHARS - 60
+
+    def test_trim_cuts_on_a_word_boundary(self):
+        """No partial word at the end: a truncated token changes the search."""
+        words = "alpha beta gamma delta epsilon".split()
+        fitted = github._fit_query(" ".join(words), 14)
+        assert not fitted.endswith(" ")
+        assert all(w in words for w in fitted.split()), fitted
+
+    def test_short_vision_is_untouched(self):
+        assert github._fit_query("a python cli", 200) == "a python cli"
+
+    def test_whitespace_is_normalised(self):
+        assert github._fit_query("  a   python\n cli ", 200) == "a python cli"
+
+    def test_422_becomes_an_actionable_error_not_a_bare_httperror(self, monkeypatch):
+        import urllib.error
+
+        def boom(url, *a, **k):
+            raise urllib.error.HTTPError(url, 422, "Unprocessable Entity", {}, None)
+
+        monkeypatch.setattr(github.urllib.request, "urlopen", boom)
+        with pytest.raises(github.GitHubQueryError) as exc:
+            github._get("https://api.github.com/search/repositories?q=x")
+        msg = str(exc.value)
+        assert "422" in msg and str(github.GITHUB_MAX_QUERY_CHARS) in msg
+
+    def test_rate_limit_handling_is_unaffected(self, monkeypatch):
+        import urllib.error
+
+        def boom(url, *a, **k):
+            raise urllib.error.HTTPError(url, 429, "Too Many Requests", {}, None)
+
+        monkeypatch.setattr(github.urllib.request, "urlopen", boom)
+        with pytest.raises(github.GitHubRateLimitError):
+            github._get("https://api.github.com/search/repositories?q=x")
+
+
+class TestNoReposGuidance:
+    def test_guidance_does_not_tell_users_to_be_more_specific(self):
+        """The failure mode is an over-long, over-specific vision."""
+        import inspect
+
+        from genesis_architect import scaffold
+        src = inspect.getsource(scaffold)
+        assert "more specific vision" not in src
+        assert "very long or very niche" in src
+
+
+class TestEmptyProjectIsNotAPerfectScore:
+    def test_empty_project_is_unscored_rather_than_100(self, tmp_path):
+        result = core_score(tmp_path)
+        assert result["module_count"] == 0
+        assert result["scored"] is False
+        assert result["total"] is None, "an empty project must not report a grade"
+        assert result["unscored_reason"]
+
+    def test_real_project_is_still_scored_normally(self, tmp_path):
+        src = tmp_path / "src" / "app"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text("", encoding="utf-8")
+        (src / "main.py").write_text("from app import core\n", encoding="utf-8")
+        (src / "core.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+        result = core_score(tmp_path)
+        assert result["scored"] is True
+        assert isinstance(result["total"], int) and 0 <= result["total"] <= 100
+
+    def test_confidence_is_zero_when_nothing_was_analysed(self):
+        conf, basis = _score_confidence(0, 0, 0)
+        assert conf == 0.0
+        assert "0 modules" in basis
+
+    def test_confidence_is_low_for_a_handful_of_modules(self):
+        conf, _ = _score_confidence(2, 0, 0)
+        assert conf <= 0.35
+
+    def test_confidence_still_rises_with_real_evidence(self):
+        small, _ = _score_confidence(5, 0, 0)
+        large, _ = _score_confidence(60, 0, 5)
+        assert large > small
+
+
+class TestCommitteeIsHonestWithoutAnLLM:
+    def _ctx(self, tmp_path):
+        from genesis_architect.pro.gde_types import (
+            EngineResult, EngineStatus, GDEMode, LifecycleStage, SessionContext,
+        )
+        ctx = SessionContext(
+            session_id="s1", project_dir=tmp_path,
+            mode=GDEMode.COMMITTEE, stage=LifecycleStage.EXECUTE,
+        )
+        ctx.engine_results["architecture_scorer"] = EngineResult(
+            engine_id="architecture_scorer", status=EngineStatus.SUCCESS,
+            output={"total": 61, "score_label": "fair"})
+        return ctx
+
+    def test_missing_api_key_is_reported_not_hidden(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        from genesis_architect.pro.gde_engine_adapters import gde_run_committee_analysis
+        out = gde_run_committee_analysis(self._ctx(tmp_path))
+        joined = " ".join(out.get("_warnings", []))
+        assert "ANTHROPIC_API_KEY" in joined
+        assert "not a Committee debate" in joined
+
+    def test_fallback_never_claims_full_confidence(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        from genesis_architect.pro.gde_engine_adapters import gde_run_committee_analysis
+        out = gde_run_committee_analysis(self._ctx(tmp_path))
+        assert out["_confidence"] <= 0.6, "aggregation must not report certainty"
+
+    def test_fallback_report_is_not_titled_committee_analysis(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        from genesis_architect.pro.gde_engine_adapters import gde_run_committee_analysis
+        out = gde_run_committee_analysis(self._ctx(tmp_path))
+        payload = out["_pending_writes"][0]["payload"]
+        assert "Engine Perspectives" in payload
+        assert "not a Committee debate" in payload
+
+
+class TestNoLicenceTierLeftovers:
+    def test_committee_transparency_is_not_gated_on_a_licence_tier(self):
+        """Everyone gets the full transcript: there are no tiers any more."""
+        import inspect
+
+        from genesis_architect.pro import gde_engine_adapters
+        src = inspect.getsource(gde_engine_adapters.gde_run_committee_analysis)
+        assert "license_tier" not in src
+        assert "TransparencyProfile.FREE" not in src


### PR DESCRIPTION
First user report against 8.0.0. All four findings verified and fixed.

- `genesis init` crashed with a bare HTTP 422 traceback on visions over GitHub's 256-char query limit (reproduced at 496 chars)
- the empty-result advice said "try a more specific vision", which is backwards
- an empty project scored a perfect 100/100 with 0 modules analysed and 0.65 confidence: a false green also triggered by a wrong `--dir` or an unsupported language
- the Committee silently fell back to perspective aggregation without an LLM key and reported it at up to 100% confidence under a "Committee Analysis" heading

Also removed a paid-tier leftover found on that path: the Committee withheld the full transcript from "free" users via a `license_tier` lookup.

2358 tests passing, 16 new regressions.