### PR TITLE
docs: architecture reference, site copy, and a corrected README for 9.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
         run: |
           found=$(LC_ALL=C.UTF-8 grep -rnP '\x{2014}|\x{2013}' \
             README.md SKILL.md CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md \
+            ARCHITECTURE.md WEBSITE_COPY.md \
             2>/dev/null || true)
           if [ -n "$found" ]; then
             echo "FAIL: em/en dashes found in reader-facing docs:"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,317 @@
+# Genesis Architect - Structural Reference
+
+How the analysis actually works: the graph it builds, the rules it applies to
+that graph, the thresholds, and the discriminators that decide whether a
+finding is a defect or a false alarm.
+
+This document is about mechanism. For what Genesis produces, see the
+[README](../README.md).
+
+---
+
+## 1 · The dependency graph
+
+Everything structural derives from one artifact: a directed graph of modules
+and the imports between them.
+
+### Extraction
+
+Imports come from the parsed syntax tree, not from a text scan. The practical
+consequence is that a module named in a docstring, a comment, or a string
+literal is not an edge - a regex-based scanner reports those as dependencies
+and inflates every downstream metric.
+
+Five languages, each with its own extractor:
+
+| Language | Detected by | Import forms read |
+|---|---|---|
+| Python | `pyproject.toml`, `setup.py` | `import x`, `from x import y` (dotted paths kept) |
+| TypeScript / JavaScript | `package.json` | `import`, `require` |
+| Go | `go.mod` | import blocks |
+| Rust | `Cargo.toml` | `use`, `mod` |
+
+For Python, `from app import billing` records the dotted candidate
+`app.billing` as well as `app`, because the former is a real submodule edge
+when `app/billing.py` exists. The resolver drops the candidate when it maps to
+nothing on disk, so the guess costs nothing when wrong.
+
+### What is deliberately not an edge
+
+**`if TYPE_CHECKING:` bodies.** Those imports never execute. Counting them
+overstates coupling, and it makes two reasonable goals mutually exclusive: a
+module that declares its re-exports so type checkers can see a lazy API would
+register that declaration as runtime fan-out.
+
+Two cases inside the same construct *are* walked, because that code runs:
+
+```python
+if TYPE_CHECKING:
+    from pkg.types_only import Thing      # not an edge
+else:
+    from pkg.at_runtime import Thing      # edge - else runs
+
+if not TYPE_CHECKING:
+    from pkg.also_runs import Other       # edge - negated guard runs
+```
+
+> Matching the bare name `TYPE_CHECKING` as the guard would invert the third
+> case exactly. The negated form is checked for, not assumed away.
+
+### Cycle detection
+
+Cycles are found with Kahn's algorithm: repeatedly remove nodes with in-degree
+zero. Whatever cannot be removed is, by construction, inside a cycle. This is
+deterministic and reports the participating members rather than a single edge,
+because a cycle has no privileged "cause" to point at.
+
+---
+
+## 2 · The analysis rules
+
+Three structural rules, each with a threshold and - more importantly - a
+discriminator that separates the pattern from the defect.
+
+### god-class - fan-out
+
+| | |
+|---|---|
+| Flags at | `fan_out > 15` |
+| Critical at | `fan_out > 30` |
+| Reads | outgoing edges |
+
+A module importing many others has taken on many jobs, and a change to any of
+them can reach it.
+
+**Discriminator - the standalone script.** A file that nothing imports, living
+outside any package, is a script. Its coupling is *terminal*: it cannot cascade
+a change to anything, because nothing depends on it. An audit runner, a build
+script or a one-off migration reaches across the whole system by design.
+
+Both conditions are required:
+
+```
+fan_in == 0          nothing depends on it
+not in a package     its directory holds no __init__.py
+```
+
+Requiring both is what stops the rule excusing a genuine god module that merely
+has no importers *yet*. A module inside a package stays CRITICAL whether
+anything imports it or not, and a script gains its verdict back the moment
+something imports it. Package membership is derived from the graph itself, so
+no directory layout is hardcoded.
+
+### hub-file - fan-in
+
+| | |
+|---|---|
+| Flags at | `fan_in > 10` |
+| Critical at | `fan_in > 20` |
+| Reads | incoming edges, excluding tests |
+
+**Discriminator 1 - tests are not coupling.** A test is a leaf. Nothing depends
+on it, so a change to the module cannot cascade *through* it to anything else.
+Counting test importers meant **adding tests degraded a project's architecture
+score**, which is an incentive no analysis tool should create.
+
+Test importers are excluded from the verdict and reported separately, so
+excluding them from the judgement does not hide them from the report:
+
+```
+metrics: { fan_in, fan_in_including_tests, test_importers, fan_out }
+```
+
+**Discriminator 2 - a vocabulary is not a hub.** A module with high fan-in and
+*zero* fan-out is a shared type or constant vocabulary. It cannot propagate a
+change it never receives. The standard advice - extract the stable interface
+into its own module - is incoherent when the module already *is* that
+interface; acting on it yields two vocabularies and duplicated definitions.
+Reported at LOW, with a fix line that says to leave it alone.
+
+### circular-dep
+
+Every cycle is CRITICAL. There is no threshold, because there is no acceptable
+number of import cycles: each one means neither module can be understood,
+tested or loaded without the other.
+
+---
+
+## 3 · The engine DAG
+
+Analysis engines are registered as descriptors carrying two different kinds of
+edge. Conflating them is the mistake this design exists to prevent.
+
+| Edge | Direction | Meaning | Cycles |
+|---|---|---|---|
+| `requires` | backward | hard ordering constraint | **must stay acyclic** |
+| `handoffs` | forward | "having run, this is useful next" | **legal** |
+
+`requires` is topologically sorted to produce the execution plan, so a cycle
+there means no valid order exists and the plan is refused.
+
+`handoffs` is advisory and deliberately exempt from cycle detection. The
+shipped registry contains a real handoff loop:
+
+```
+recovery_report → refactoring_planner → rules_engine → recovery_report
+```
+
+That is `diagnose → plan → enforce → re-diagnose` - an iterative workflow, not
+a structural defect. Handoff targets are existence-checked so they cannot rot
+into dangling references, and nothing more.
+
+> Nothing traverses `handoffs` at runtime. The runner iterates a pre-computed
+> list of phases, so each engine executes at most once per session and a handoff
+> loop cannot spin. The day something *does* follow them, the bound belongs at
+> the point of traversal.
+
+### The composition root
+
+Registration is owned by one module. Previously it had no owner: whichever
+module first noticed the registry was empty triggered it, which meant the
+registry imported the thing that fills it, and a descriptor provider imported
+its sibling. Three of four import cycles came from that.
+
+```
+gde_types                    imports nothing intra-package
+    ↑
+engine_registry              a container, and only a container
+    ↑
+gde_engine_registration      providers; they import the registry
+gde_knowledge_graph_adapter  to register into it
+    ↑
+engine_bootstrap             imports the providers, in order
+    ↑
+decision_engine / CLI        entry points ask for the bootstrap
+```
+
+Every arrow points one way. The registry can no longer reach the providers, so
+the cycle cannot re-form by someone adding another lazy import - there is now
+an obvious place for that code to go instead.
+
+---
+
+## 4 · The gate table
+
+Fourteen gates evaluate a session before any write is approved. Each carries an
+action and a confidence penalty.
+
+| Action | Gates | Overridable |
+|---|---|---|
+| `HARD_BLOCK` | `PLAN_WRITE`, `RULES_FAIL` | **no** |
+| `BLOCK_AND_ASK` | `CONFIDENCE_LOW`, `DRIFT_CRITICAL`, `SECURITY_RISK`, `POLICY_VIOLATION`, `COMMIT_CONFLICT`, `RED_TEAM_CRITICAL`, `RESEARCH_COVERAGE_LOW` | yes |
+| `WARN` | `WRITE_SCOPE`, `REQUIRED_FAILED`, `DEGRADED_MODE`, `NO_ENGINES`, `RESEARCH_STALE` | yes |
+
+Penalties run 0.05 for warnings to 0.15 for soft blocks, subtracted from the
+session's overall confidence.
+
+Several gates scan *every* engine's output for a signal key rather than naming
+one engine. `SECURITY_RISK` looks for `security_risk` from any engine, so a new
+analysis engine wires into the gate by emitting the key - the gate does not
+change.
+
+### Absent is not zero
+
+A metric that was never measured is reported as `None`, never as `0`. Coverage
+with no outline to measure against is "not applicable"; a repository with no
+star count is unknown, not unpopular. Rules skip on `None` rather than treating
+it as a failing value, and the report says *skipped* rather than *passed*.
+
+> "Checked and clean" and "nothing to check" are different results. Only one of
+> them is evidence.
+
+---
+
+## 5 · How structural changes are verified
+
+The 9.0.0 refactor moved roughly 2,000 lines across nine new modules. Three
+techniques carried that, and they generalise.
+
+### Behavioural oracle before a mechanical move
+
+A snapshot tool walks the argument parser and dumps every subcommand, flag,
+`nargs`, default, type, `choices` and help string - 413 lines. Captured from a
+worktree at the pre-refactor commit, diffed after every step.
+
+That turns "did the CLI change?" from a hope into a fact. It stayed
+byte-identical through all six steps of the split.
+
+### Static undefined-name checking after every move
+
+`ruff --select F821` ran after each extraction. It caught **three defects the
+full 2,845-test suite passed straight over**, because they sat on uncovered
+error paths: a relocated module lost its `sys` import, and a formatter lost
+`Path`. Tests alone are not sufficient for relocations.
+
+### Conserved lint debt as evidence
+
+Before the CLI split: 19 `I001` findings. After: 19. None introduced.
+
+The relocated function-local import blocks carried their own pre-existing
+formatting debt along unchanged. That equality is the cheapest available
+evidence that the moves were faithful rather than rewritten - a genuine
+rewrite would almost certainly have changed the count in one direction.
+
+---
+
+## 6 · Genesis measured against itself
+
+Every number below is produced by the rules above, run against this repository.
+
+| | before 9.0.0 | after |
+|---|---|---|
+| Import cycles | 4 | **0** |
+| Critical anti-patterns | 7 | **0** |
+| Unpinned CI actions | 21 | **0** |
+| Largest module fan-out | 31 | **9** |
+| Largest module, lines | 1,974 | 390 |
+| Architecture score | 67 | **89** |
+| Tests | 2,337 | **2,845** |
+
+The CLI package after the split, against a self-imposed ceiling of 11:
+
+| Module | fan-out | lines |
+|---|---|---|
+| `commands/parser.py` | 0 | 246 |
+| `commands/formatting.py` | 1 | 335 |
+| `commands/voice_setup.py` | 3 | 217 |
+| `commands/session_cmds.py` | 4 | 259 |
+| `commands/project_cmds.py` | 7 | 268 |
+| `commands/analysis_cmds.py` | 7 | 232 |
+| `commands/router.py` | 8 | 154 |
+| `commands/companion_cmds.py` | 8 | 350 |
+| `commands/companion_backend.py` | 9 | 112 |
+| `gde_cli.py` (compatibility shim) | 1 | 132 |
+
+> The ceiling is 11 against a rule that flags at 15. A module sitting exactly on
+> a threshold is a latent breach, not a pass - the next feature tips it over.
+
+`companion_backend.py` exists because relocation alone could not get the
+companion family under the ceiling: it measured 14, and every pure-move seam
+landed at 11 or 12. The cause was real duplication - `--serve` and `--ui`
+brought the backend up with the same seven imports and the same seven steps in
+the same order. Two copies of a startup sequence is a live bug risk on its own,
+since a fix to one can miss the other.
+
+Their *teardowns* genuinely differ, and that asymmetry was preserved rather
+than tidied away. Unifying it would have been a behaviour change wearing the
+costume of a refactor.
+
+---
+
+## 7 · Reproducing any of this
+
+```bash
+# Structure of your own project
+genesis recover .
+
+# The same graph Genesis uses on itself
+python -c "from genesis_architect.core.import_graph import build_graph; \
+           g = build_graph('.'); \
+           print(g['cycle_count'], 'cycles across', g['module_count'], 'modules')"
+
+# Full suite plus end-to-end CLI checks against a real install
+docker build -f Dockerfile.test -t genesis-test . && docker run --rm genesis-test
+```
+
+Nothing in this document is asserted rather than measured. If a number here
+disagrees with what the tool reports on your machine, the tool is right.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ modules are too fragile to touch.
 [![PyPI](https://img.shields.io/pypi/v/genesis-architect?style=flat-square)](https://pypi.org/project/genesis-architect/)
 [![Python](https://img.shields.io/pypi/pyversions/genesis-architect?style=flat-square)](https://pypi.org/project/genesis-architect/)
 [![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-2337-brightgreen?style=flat-square)](tests/)
+[![Tests](https://img.shields.io/badge/tests-2845%20passing-brightgreen?style=flat-square)](tests/)
+[![Cycles](https://img.shields.io/badge/import%20cycles-0-brightgreen?style=flat-square)](ARCHITECTURE.md)
+[![Anti-patterns](https://img.shields.io/badge/critical%20anti--patterns-0-brightgreen?style=flat-square)](ARCHITECTURE.md)
 
 </div>
 
@@ -33,6 +35,38 @@ modules are too fragile to touch.
 > that was behind the paywall (decision engine, knowledge graph, threat modelling, C4
 > component diagrams, voice companion, video-to-pitfall) ships in this package under
 > AGPL-3.0. No key, no account, no telemetry by default.
+
+---
+
+## Genesis audited itself
+
+The obvious question about a tool that grades architecture is whether it would
+survive its own grading. In v9.0.0 it was pointed at its own source, and the
+answer was no. It found four import cycles, seven critical anti-patterns, a
+1,974-line CLI module importing 31 others, and twenty-one CI actions pinned to
+tags that their owners could move at any time.
+
+All of it is now zero.
+
+| | before | after |
+|---|---|---|
+| Import cycles | 4 | **0** |
+| Critical anti-patterns | 7 | **0** |
+| Unpinned CI actions | 21 | **0** |
+| Largest module fan-out | 31 | **9** |
+| Architecture score | 67 | **89** |
+
+> Three of the rules that produced those findings turned out to be wrong, and
+> fixing them was part of the release. The hub-file rule counted *test* files as
+> coupling, which meant adding tests degraded your score. It could not tell a
+> shared type vocabulary from a hub, or a standalone script from a god class.
+> Each now discriminates on evidence from the dependency graph.
+>
+> **Your scores may move on 9.0.0.** That is the correction landing, not a
+> regression.
+
+The full method, including how interface parity was proven byte-for-byte across
+a nine-module split, is in [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ---
 
@@ -154,6 +188,39 @@ Before writing a file, Genesis runs real research:
 
 The difference from a template: the scaffold reflects what actually broke for the
 people who built this before you.
+
+---
+
+## Under the hood
+
+Four mechanisms do most of the structural work. Each is small, and each exists
+because the obvious alternative was measurably wrong.
+
+**Dependency graphs from the AST, not from text.** Imports are read by walking
+the parsed tree, so a module named in a docstring or a comment is not an edge.
+Imports under `if TYPE_CHECKING:` are pruned too - they never execute, so they
+are not dependencies. The `else:` branch and `if not TYPE_CHECKING:` *are*
+walked, because that code does run.
+
+**Fan-out ceilings with margin.** A module importing more than 15 others is
+flagged; above 30 it is critical. Genesis holds its own modules to 11, and the
+widest is 9. A module sitting exactly on a threshold is a latent breach, not a
+pass.
+
+**Cycle detection on the hard edges only.** Engines declare `requires`
+(a backward edge, topologically sorted, must stay acyclic) separately from
+`handoffs` (a forward edge, advisory). Handoff loops are legal on purpose:
+`diagnose -> plan -> enforce -> re-diagnose` is a workflow, not a defect.
+
+**Lazy public API (PEP 562).** Importing `genesis_architect.pro` used to pull in
+all 43 of its modules. Names now resolve on first attribute access; the API is
+identical and fewer than ten submodules load. The eager imports are kept under
+`if TYPE_CHECKING:` so type checkers and static analysis still see the whole
+surface - which costs nothing at runtime and, since the scanner understands the
+guard, nothing in coupling either.
+
+> Every one of those claims is measured in CI, not asserted here. `genesis
+> recover .` will tell you the same numbers about your own project.
 
 ---
 

--- a/WEBSITE_COPY.md
+++ b/WEBSITE_COPY.md
@@ -1,0 +1,230 @@
+# Website Copy - v9.0.0
+
+Copy blocks for the landing page (`genesis-react`), structured for direct
+lifting into components. Dark-mode first.
+
+**Voice rules for anything added later:** declarative, specific, no superlatives
+Genesis has not earned. Every number on the page is measured and reproducible by
+a visitor running one command. If a claim cannot survive `genesis recover .` on
+our own repo, it does not ship.
+
+---
+
+## 1 · Hero
+
+**Headline**
+
+> ### Research before you build.
+
+**Alternate headlines**, if the page needs a structural angle rather than a
+research one:
+
+> ### The architecture tool that audited itself.
+> ### Most projects fail by repeating a solved mistake.
+
+**Subheadline**
+
+> Genesis reads the repositories that already solved your problem - their closed
+> issues, their forks, their post-mortems - and scaffolds a project with those
+> failures already mitigated. Then it stays, and tells you which modules have
+> become too fragile to touch.
+
+**Primary CTA:** `pip install genesis-architect` (click-to-copy)
+**Secondary CTA:** View on GitHub
+
+**Trust strip** - render as small monospace chips under the fold line:
+
+```
+AGPL-3.0   ·   Python 3.11+   ·   2,845 tests   ·   0 import cycles   ·   no telemetry by default
+```
+
+---
+
+## 2 · The proof section
+
+Place immediately below the hero. This is the strongest thing on the page: it
+is the only claim a competitor cannot copy without doing the work.
+
+**Eyebrow:** `v9.0.0 - The Architecture Milestone`
+
+**Headline**
+
+> ### We pointed it at ourselves. It failed.
+
+**Body**
+
+> The obvious question about a tool that grades architecture is whether it would
+> survive its own grading. In 9.0.0 we ran it against its own source. It found
+> four import cycles, seven critical anti-patterns, a 1,974-line CLI module
+> importing 31 others, and 21 CI actions pinned to tags their owners could move
+> at any time.
+>
+> All of it is now zero.
+
+**Metric row** - four tiles, before → after:
+
+| Label | Before | After |
+|---|---|---|
+| Import cycles | 4 | 0 |
+| Critical anti-patterns | 7 | 0 |
+| Unpinned CI actions | 21 | 0 |
+| Architecture score | 67 | 89 |
+
+**Footnote, small type**
+
+> Three of the rules that produced those findings turned out to be wrong, and
+> fixing them shipped in the same release. Scores may move on 9.0.0. That is the
+> correction landing, not a regression.
+
+---
+
+## 3 · Under the hood
+
+**Headline**
+
+> ### Four mechanisms, each because the obvious alternative was measurably wrong.
+
+Render as four cards. Title, one-line claim, then the mechanism.
+
+```jsx
+const mechanisms = [
+  {
+    title: "Graphs from the AST, not from text",
+    claim: "A module named in a comment is not a dependency.",
+    body:
+      "Imports are read by walking the parsed syntax tree. A regex scanner " +
+      "reports docstrings and string literals as edges and inflates every " +
+      "metric downstream. Five languages: Python, TypeScript, JavaScript, Go, Rust.",
+  },
+  {
+    title: "TYPE_CHECKING is not a dependency",
+    claim: "Imports that never execute are not coupling.",
+    body:
+      "Imports under `if TYPE_CHECKING:` are pruned - they never run. The " +
+      "`else:` branch and `if not TYPE_CHECKING:` are kept, because that code " +
+      "does. Matching the bare name as the guard would invert the second case exactly.",
+  },
+  {
+    title: "Discriminators, not just thresholds",
+    claim: "A shared vocabulary is not a hub. A script is not a god class.",
+    body:
+      "High fan-in with zero fan-out is a type vocabulary: it cannot propagate " +
+      "a change it never receives. A file nothing imports, outside any package, " +
+      "is a script: its coupling is terminal. Both are reported, neither is a defect.",
+  },
+  {
+    title: "Test files are not coupling",
+    claim: "Adding tests must never lower your score.",
+    body:
+      "A test is a leaf - nothing depends on it, so a change cannot cascade " +
+      "through it. Counting test importers created an incentive to delete tests. " +
+      "They are excluded from the verdict and reported separately.",
+  },
+];
+```
+
+**Section footer**
+
+> Every claim above is measured in CI, not asserted on a marketing page.
+> `genesis recover .` reports the same numbers about your project.
+
+---
+
+## 4 · What it produces
+
+Keep the README's worked example verbatim - real issue URLs, the generated
+tree, the "every cited URL is checked by CI; a 404 fails the build" line. It is
+the most persuasive block we have and it should not be paraphrased into
+something softer for the web.
+
+Render the pitfall table as-is. Do not truncate the issue links: the fact that
+they are real, clickable, and CI-verified *is* the argument.
+
+---
+
+## 5 · Everything is free
+
+> ⚠️ **Replaces the old "Pro vs Core" section.** There is no paid tier. Genesis
+> was open-core until v8.0.0 - a free package plus a license-gated
+> `genesis-architect-pro`. That tier is retired. Any page still showing a
+> pricing table, a "Pro" badge, or an upgrade CTA is stale and should be
+> removed, not restyled.
+
+**Headline**
+
+> ### There is no paid tier.
+
+**Body**
+
+> Genesis used to be open-core. As of v8.0.0 every engine that was behind the
+> paywall ships in the package under AGPL-3.0: the decision engine, the
+> knowledge graph, threat modelling, C4 diagrams, the voice companion,
+> video-to-pitfall extraction. No key, no account, no telemetry by default.
+
+**If the page needs a structural distinction**, this is the honest one - two
+namespaces in one free package, not two products:
+
+| | |
+|---|---|
+| `genesis_architect.core` | Research, scaffolding, the import graph, the base analysis rules. The primitives. |
+| `genesis_architect.pro` | The intelligence layer built on them: decision engine, knowledge graph, threat modelling, companion. Named `pro` for historical reasons only. |
+
+---
+
+## 6 · Install
+
+```bash
+pip install genesis-architect
+```
+
+> That is the whole install. Optional extras add voice and the streaming
+> Companion UI: `pip install "genesis-architect[all]"`.
+
+**Three commands, as tabs or a terminal component:**
+
+```bash
+genesis init a Python CLI for analyzing log files   # research, then scaffold
+genesis recover .                                   # drift, cycles, fragility
+genesis harden .                                    # STRIDE, OWASP, secrets
+```
+
+---
+
+## 7 · When not to use it
+
+Keep this section. Naming where the tool is a bad fit buys more credibility
+than another feature tile.
+
+> Genesis is overkill for a throwaway script, a one-off utility, or anything
+> under 100 lines you will delete next week. It earns its keep on projects you
+> intend to maintain, anything touching auth, file I/O or external APIs, and
+> libraries other people will depend on.
+
+---
+
+## 8 · Footer
+
+```
+AGPL-3.0-or-later · © 2026 Maio Eshet
+Use, modify and redistribute freely, including commercially. The one obligation:
+if you modify it and offer it to others over a network, publish your modified
+source under the same license. Running it on your own code changes nothing.
+```
+
+---
+
+## Numbers to update at each release
+
+Single source of truth for the page. All are reproducible from the repo.
+
+| Token | v9.0.0 | Source |
+|---|---|---|
+| `TESTS` | 2,845 | `pytest --co -q` |
+| `CYCLES` | 0 | `build_graph('.')['cycle_count']` |
+| `CRITICALS` | 0 | `detect_all('.').critical_count` |
+| `SCORE` | 89 | `score_project('.')['total']` |
+| `ENGINES` | 19 | `get_default_registry()` |
+| `PY_MIN` | 3.11 | `pyproject.toml` |
+
+> If any of these drift from the page, the page is wrong. Wire them to the
+> release checklist rather than editing by hand.


### PR DESCRIPTION
Three documentation deliverables for 9.0.0, plus two corrections found during review.

**`ARCHITECTURE.md`** (new) - how the analysis actually works. The AST-derived dependency graph and why it is not a text scan, what is deliberately excluded, Kahn's algorithm for cycles, the three structural rules with thresholds *and* discriminators, the `requires`/`handoffs` split, the fourteen-gate table, and the three techniques that verified the 9.0.0 refactor. Every number is measured; the last section shows how to reproduce any of them.

**`WEBSITE_COPY.md`** (new) - hero, proof section, four "under the hood" cards as a JSX-ready array, and a table of release-varying numbers wired to the commands that produce them, so the page cannot silently drift from the repo.

**`README.md`** - gains the self-audit story and an "Under the hood" section. Everything else untouched: the worked example with real, CI-verified issue URLs is the strongest thing in the file.

### Two corrections

**The tests badge read 2337.** It is 2845, and had been stale for two releases. Badges for zero cycles and zero critical anti-patterns added alongside.

**Both documents were first written into `docs/`, which is wrong.** `docs/` is the built site - `index.html`, favicons, assets, generated demo pages, published via Pages. Markdown left there is served as site content and overwritten by the next site build. They are at repo root instead, and both are now covered by the CI style gate governing the other reader-facing prose.

### Not written

A "Pro vs Core" comparison. There is no paid tier - open-core was retired in v8.0.0 and the README already says so. A pricing section would contradict the package it ships in. `WEBSITE_COPY.md` documents the honest distinction instead (two namespaces, one free package) and flags any surviving pricing table on the site as stale.

### Verification

2845 tests passing. Style gate, SKILL.md budget and every README link checked locally against the exact commands CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)